### PR TITLE
added follow-redirect and updated path to include url queries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "@kie/act-js",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kie/act-js",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@kie/mock-github": "^1.0.1",
         "ajv": "^8.12.0",
         "express": "^4.18.1",
+        "follow-redirects": "^1.15.2",
         "yaml": "^2.1.3"
       },
       "bin": {
@@ -20,6 +21,7 @@
       "devDependencies": {
         "@octokit/rest": "^19.0.5",
         "@types/express": "^4.17.13",
+        "@types/follow-redirects": "^1.14.1",
         "@types/jest": "^28.1.3",
         "@types/node": "^18.0.0",
         "@typescript-eslint/eslint-plugin": "^5.48.2",
@@ -1551,6 +1553,15 @@
         "@types/node": "*",
         "@types/qs": "*",
         "@types/range-parser": "*"
+      }
+    },
+    "node_modules/@types/follow-redirects": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@types/follow-redirects/-/follow-redirects-1.14.1.tgz",
+      "integrity": "sha512-THBEFwqsLuU/K62B5JRwab9NW97cFmL4Iy34NTMX0bMycQVzq2q7PKOkhfivIwxdpa/J72RppgC42vCHfwKJ0Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/graceful-fs": {
@@ -3194,7 +3205,6 @@
       "version": "1.15.2",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
       "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -7346,6 +7356,15 @@
         "@types/range-parser": "*"
       }
     },
+    "@types/follow-redirects": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@types/follow-redirects/-/follow-redirects-1.14.1.tgz",
+      "integrity": "sha512-THBEFwqsLuU/K62B5JRwab9NW97cFmL4Iy34NTMX0bMycQVzq2q7PKOkhfivIwxdpa/J72RppgC42vCHfwKJ0Q==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/graceful-fs": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -8585,8 +8604,7 @@
     "follow-redirects": {
       "version": "1.15.2",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
-      "dev": true
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
     },
     "form-data": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kie/act-js",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "nodejs wrapper for nektos/act",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -41,6 +41,7 @@
   "devDependencies": {
     "@octokit/rest": "^19.0.5",
     "@types/express": "^4.17.13",
+    "@types/follow-redirects": "^1.14.1",
     "@types/jest": "^28.1.3",
     "@types/node": "^18.0.0",
     "@typescript-eslint/eslint-plugin": "^5.48.2",
@@ -60,6 +61,7 @@
     "@kie/mock-github": "^1.0.1",
     "ajv": "^8.12.0",
     "express": "^4.18.1",
+    "follow-redirects": "^1.15.2",
     "yaml": "^2.1.3"
   },
   "jestSonar": {

--- a/src/mockapi/request/request-mocker.ts
+++ b/src/mockapi/request/request-mocker.ts
@@ -3,7 +3,7 @@ import { MockapiResponseMocker } from "@aj/mockapi/response/response-mocker";
 
 export class MockapiRequestMocker extends RequestMocker {
   constructor(baseUrl: string, endpointDetails: EndpointDetails, allowUnmocked = false) {
-    super(baseUrl, endpointDetails);
+    super(baseUrl, endpointDetails, allowUnmocked);
 
     // need to bind the instance context to the function. otherwise it is lost during method generation
     this.request = this.request.bind(this);

--- a/src/proxy/proxy.ts
+++ b/src/proxy/proxy.ts
@@ -1,6 +1,7 @@
 import net from "net";
 import express from "express";
-import http from "http";
+import { http } from "follow-redirects";
+import { Server } from "http";
 import { ResponseMocker } from "@kie/mock-github";
 import { networkInterfaces } from "os";
 import internal from "stream";
@@ -8,7 +9,7 @@ import internal from "stream";
 export class ForwardProxy {
   private apis: ResponseMocker<unknown, number>[];
   private app: express.Express;
-  private server: http.Server;
+  private server: Server;
   private logger: (msg: string) => void;
   private currentConnections: Record<number, internal.Duplex>;
   private currentSocketId: number;
@@ -128,10 +129,9 @@ export class ForwardProxy {
 
     // forward the intercepted api call
     this.app.all("/*", function (req, res) {
-      logger(req.baseUrl + req.path);
       const opts = {
         host: req.hostname,
-        path: req.path,
+        path: req.path + new URL(req.url).search,
         method: req.method,
         headers: req.headers,
         agent: false,

--- a/test/unit/proxy/proxy.test.ts
+++ b/test/unit/proxy/proxy.test.ts
@@ -110,17 +110,17 @@ describe("http", () => {
     const proxy = new ForwardProxy([
       mockapi.mock.google.root
         .get()
-        .setResponse({ status: 200, data: { msg: "mocked_response" } }),
+        .setResponse({ status: 400, data: { msg: "mocked_response" } }),
     ]);
     const ip = await proxy.start();
     process.env["http_proxy"] = `http://${ip}`;
     process.env["https_proxy"] = `http://${ip}`;
 
-    await expect(
-      axios.get("http://redhat.com/", {
-        maxRedirects: 0,
-      })
-    ).rejects.toThrowError("Request failed with status code 301");
+    const { status } = await axios.get("http://redhat.com/");
+
+    expect(
+      status
+    ).toBe(200);
     await proxy.stop();
   });
 });


### PR DESCRIPTION
Resolves a bug where when using the proxy, we would reach max redirect when the http requested url will return a 301 to redirect to the https version. When we would receive this 301, the proxy would pass this response to actual client. If client decided to follow the redirect and request the https url, it would again be intercepted by the proxy which would make an http request and the cycle would repeat.

Resolves a bug where url query wasn't being passed by the proxy to the actual target.