### PR TITLE
feat: handle `CONNECT` requests for http destinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,13 +285,12 @@ let result = await act.runEventAndJob("pull_request", "jobId");
 
 #### Mocking apis during the run
 
-You can use [Mockapi](#mockapi) and [Moctokit](https://github.com/kiegroup/mock-github#moctokit) to mock any kind of HTTP and HTTPS requests during your workflow run provided that the client being used honours HTTP_PROXY and HTTPS_PROXY env variables. Depending on the client, for HTTPS they might issue a CONNECT request to open a secure TCP tunnel. In this case `Act` won't be able to mock the HTTPS request.
-(Note - For Octokit, you can mock HTTPS requests because it does not issues a CONNECT request)
+You can use [Mockapi](#mockapi) and [Moctokit](https://github.com/kiegroup/mock-github#moctokit) to mock any kind of HTTP and HTTPS requests during your workflow run provided that the client being used honors HTTP_PROXY and HTTPS_PROXY env variables. Depending on the client, for HTTPS they might issue a CONNECT request to open a secure TCP tunnel. In this case `Act` won't be able to mock the HTTPS request.
 
 ```typescript
 import { Moctokit } from "@kie/mock-github";
 import { Mockapi } from "@kie/act-js";
-const moctokit = new Moctokit();
+const moctokit = new Moctokit("http://api.github.com");
 const mockapi = new Mockapi({
   customApi: {
     baseUrl: "http://custom-api.com",
@@ -325,6 +324,12 @@ let result = await act.runEvent("pull_request", {
   ],
 });
 ```
+
+For testing actions which use `Octokit`, you will need to make sure that `Octokit` instance is configured to use proxies. You can do so by using [ProxyAgent](https://github.com/octokit/octokit.js#proxy-servers-nodejs-only) or using the hydrated `Octokit` instance from [@actions/github](https://github.com/actions/toolkit/tree/main/packages/github).
+
+Examples to help you get started:
+- [Using ProxyAgent with Octokit](https://github.com/shubhbapna/mock-github-act-js-examples/tree/main/custom-actions/javascript)
+- [Testing @actions/github-script which uses @actions/github internally](https://github.com/shubhbapna/mock-github-act-js-examples/tree/main/workflow/github-script)
 
 #### Mocking steps
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "act-js": "bin/act"
       },
       "devDependencies": {
+        "@actions/github": "^5.1.1",
         "@octokit/rest": "^19.0.5",
         "@types/express": "^4.17.13",
         "@types/follow-redirects": "^1.14.1",
@@ -43,6 +44,138 @@
         "ts-node": "^10.8.1",
         "tsc-alias": "^1.7.1",
         "typescript": "^4.7.4"
+      }
+    },
+    "node_modules/@actions/github": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@actions/github/-/github-5.1.1.tgz",
+      "integrity": "sha512-Nk59rMDoJaV+mHCOJPXuvB1zIbomlKS0dmSIqPGxd0enAXBnOfn4VWF+CGtRCwXZG9Epa54tZA7VIRlJDS8A6g==",
+      "dev": true,
+      "dependencies": {
+        "@actions/http-client": "^2.0.1",
+        "@octokit/core": "^3.6.0",
+        "@octokit/plugin-paginate-rest": "^2.17.0",
+        "@octokit/plugin-rest-endpoint-methods": "^5.13.0"
+      }
+    },
+    "node_modules/@actions/github/node_modules/@octokit/auth-token": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.5.0.tgz",
+      "integrity": "sha512-r5FVUJCOLl19AxiuZD2VRZ/ORjp/4IN98Of6YJoJOkY75CIBuYfmiNHGrDwXr+aLGG55igl9QrxX3hbiXlLb+g==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/types": "^6.0.3"
+      }
+    },
+    "node_modules/@actions/github/node_modules/@octokit/core": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.6.0.tgz",
+      "integrity": "sha512-7RKRKuA4xTjMhY+eG3jthb3hlZCsOwg3rztWh75Xc+ShDWOfDDATWbeZpAHBNRpm4Tv9WgBMOy1zEJYXG6NJ7Q==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/auth-token": "^2.4.4",
+        "@octokit/graphql": "^4.5.8",
+        "@octokit/request": "^5.6.3",
+        "@octokit/request-error": "^2.0.5",
+        "@octokit/types": "^6.0.3",
+        "before-after-hook": "^2.2.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@actions/github/node_modules/@octokit/endpoint": {
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.12.tgz",
+      "integrity": "sha512-lF3puPwkQWGfkMClXb4k/eUT/nZKQfxinRWJrdZaJO85Dqwo/G0yOC434Jr2ojwafWJMYqFGFa5ms4jJUgujdA==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/types": "^6.0.3",
+        "is-plain-object": "^5.0.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@actions/github/node_modules/@octokit/graphql": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.8.0.tgz",
+      "integrity": "sha512-0gv+qLSBLKF0z8TKaSKTsS39scVKF9dbMxJpj3U0vC7wjNWFuIpL/z76Qe2fiuCbDRcJSavkXsVtMS6/dtQQsg==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/request": "^5.6.0",
+        "@octokit/types": "^6.0.3",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@actions/github/node_modules/@octokit/openapi-types": {
+      "version": "12.11.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-12.11.0.tgz",
+      "integrity": "sha512-VsXyi8peyRq9PqIz/tpqiL2w3w80OgVMwBHltTml3LmVvXiphgeqmY9mvBw9Wu7e0QWk/fqD37ux8yP5uVekyQ==",
+      "dev": true
+    },
+    "node_modules/@actions/github/node_modules/@octokit/plugin-paginate-rest": {
+      "version": "2.21.3",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.21.3.tgz",
+      "integrity": "sha512-aCZTEf0y2h3OLbrgKkrfFdjRL6eSOo8komneVQJnYecAxIej7Bafor2xhuDJOIFau4pk0i/P28/XgtbyPF0ZHw==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/types": "^6.40.0"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=2"
+      }
+    },
+    "node_modules/@actions/github/node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "5.16.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.16.2.tgz",
+      "integrity": "sha512-8QFz29Fg5jDuTPXVtey05BLm7OB+M8fnvE64RNegzX7U+5NUXcOcnpTIK0YfSHBg8gYd0oxIq3IZTe9SfPZiRw==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/types": "^6.39.0",
+        "deprecation": "^2.3.1"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=3"
+      }
+    },
+    "node_modules/@actions/github/node_modules/@octokit/request": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.3.tgz",
+      "integrity": "sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/endpoint": "^6.0.1",
+        "@octokit/request-error": "^2.1.0",
+        "@octokit/types": "^6.16.1",
+        "is-plain-object": "^5.0.0",
+        "node-fetch": "^2.6.7",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@actions/github/node_modules/@octokit/request-error": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.1.0.tgz",
+      "integrity": "sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/types": "^6.0.3",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/@actions/github/node_modules/@octokit/types": {
+      "version": "6.41.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.41.0.tgz",
+      "integrity": "sha512-eJ2jbzjdijiL3B4PrSQaSjuF2sPEQPVCPzBvTHJD9Nz+9dw2SGH4K4xeQJ77YfTq5bRQ+bD8wT11JbeDPmxmGg==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/openapi-types": "^12.11.0"
+      }
+    },
+    "node_modules/@actions/http-client": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.1.0.tgz",
+      "integrity": "sha512-BonhODnXr3amchh4qkmjPMUO8mFi/zLaaCeCAJZqch8iQqyDnVIkySjB38VHAC8IJ+bnlgfOqlhpyCUZHlQsqw==",
+      "dev": true,
+      "dependencies": {
+        "tunnel": "^0.0.6"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1277,26 +1410,6 @@
       },
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/@octokit/request/node_modules/node-fetch": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
-      "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
-      "dev": true,
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
       }
     },
     "node_modules/@octokit/rest": {
@@ -5933,6 +6046,26 @@
         "lodash": "^4.17.21"
       }
     },
+    "node_modules/node-fetch": {
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
+      "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "dev": true,
@@ -10549,6 +10682,15 @@
         "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
       }
     },
+    "node_modules/tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "dev": true,
@@ -10897,6 +11039,134 @@
     }
   },
   "dependencies": {
+    "@actions/github": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@actions/github/-/github-5.1.1.tgz",
+      "integrity": "sha512-Nk59rMDoJaV+mHCOJPXuvB1zIbomlKS0dmSIqPGxd0enAXBnOfn4VWF+CGtRCwXZG9Epa54tZA7VIRlJDS8A6g==",
+      "dev": true,
+      "requires": {
+        "@actions/http-client": "^2.0.1",
+        "@octokit/core": "^3.6.0",
+        "@octokit/plugin-paginate-rest": "^2.17.0",
+        "@octokit/plugin-rest-endpoint-methods": "^5.13.0"
+      },
+      "dependencies": {
+        "@octokit/auth-token": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.5.0.tgz",
+          "integrity": "sha512-r5FVUJCOLl19AxiuZD2VRZ/ORjp/4IN98Of6YJoJOkY75CIBuYfmiNHGrDwXr+aLGG55igl9QrxX3hbiXlLb+g==",
+          "dev": true,
+          "requires": {
+            "@octokit/types": "^6.0.3"
+          }
+        },
+        "@octokit/core": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.6.0.tgz",
+          "integrity": "sha512-7RKRKuA4xTjMhY+eG3jthb3hlZCsOwg3rztWh75Xc+ShDWOfDDATWbeZpAHBNRpm4Tv9WgBMOy1zEJYXG6NJ7Q==",
+          "dev": true,
+          "requires": {
+            "@octokit/auth-token": "^2.4.4",
+            "@octokit/graphql": "^4.5.8",
+            "@octokit/request": "^5.6.3",
+            "@octokit/request-error": "^2.0.5",
+            "@octokit/types": "^6.0.3",
+            "before-after-hook": "^2.2.0",
+            "universal-user-agent": "^6.0.0"
+          }
+        },
+        "@octokit/endpoint": {
+          "version": "6.0.12",
+          "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.12.tgz",
+          "integrity": "sha512-lF3puPwkQWGfkMClXb4k/eUT/nZKQfxinRWJrdZaJO85Dqwo/G0yOC434Jr2ojwafWJMYqFGFa5ms4jJUgujdA==",
+          "dev": true,
+          "requires": {
+            "@octokit/types": "^6.0.3",
+            "is-plain-object": "^5.0.0",
+            "universal-user-agent": "^6.0.0"
+          }
+        },
+        "@octokit/graphql": {
+          "version": "4.8.0",
+          "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.8.0.tgz",
+          "integrity": "sha512-0gv+qLSBLKF0z8TKaSKTsS39scVKF9dbMxJpj3U0vC7wjNWFuIpL/z76Qe2fiuCbDRcJSavkXsVtMS6/dtQQsg==",
+          "dev": true,
+          "requires": {
+            "@octokit/request": "^5.6.0",
+            "@octokit/types": "^6.0.3",
+            "universal-user-agent": "^6.0.0"
+          }
+        },
+        "@octokit/openapi-types": {
+          "version": "12.11.0",
+          "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-12.11.0.tgz",
+          "integrity": "sha512-VsXyi8peyRq9PqIz/tpqiL2w3w80OgVMwBHltTml3LmVvXiphgeqmY9mvBw9Wu7e0QWk/fqD37ux8yP5uVekyQ==",
+          "dev": true
+        },
+        "@octokit/plugin-paginate-rest": {
+          "version": "2.21.3",
+          "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.21.3.tgz",
+          "integrity": "sha512-aCZTEf0y2h3OLbrgKkrfFdjRL6eSOo8komneVQJnYecAxIej7Bafor2xhuDJOIFau4pk0i/P28/XgtbyPF0ZHw==",
+          "dev": true,
+          "requires": {
+            "@octokit/types": "^6.40.0"
+          }
+        },
+        "@octokit/plugin-rest-endpoint-methods": {
+          "version": "5.16.2",
+          "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.16.2.tgz",
+          "integrity": "sha512-8QFz29Fg5jDuTPXVtey05BLm7OB+M8fnvE64RNegzX7U+5NUXcOcnpTIK0YfSHBg8gYd0oxIq3IZTe9SfPZiRw==",
+          "dev": true,
+          "requires": {
+            "@octokit/types": "^6.39.0",
+            "deprecation": "^2.3.1"
+          }
+        },
+        "@octokit/request": {
+          "version": "5.6.3",
+          "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.3.tgz",
+          "integrity": "sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==",
+          "dev": true,
+          "requires": {
+            "@octokit/endpoint": "^6.0.1",
+            "@octokit/request-error": "^2.1.0",
+            "@octokit/types": "^6.16.1",
+            "is-plain-object": "^5.0.0",
+            "node-fetch": "^2.6.7",
+            "universal-user-agent": "^6.0.0"
+          }
+        },
+        "@octokit/request-error": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.1.0.tgz",
+          "integrity": "sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==",
+          "dev": true,
+          "requires": {
+            "@octokit/types": "^6.0.3",
+            "deprecation": "^2.0.0",
+            "once": "^1.4.0"
+          }
+        },
+        "@octokit/types": {
+          "version": "6.41.0",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.41.0.tgz",
+          "integrity": "sha512-eJ2jbzjdijiL3B4PrSQaSjuF2sPEQPVCPzBvTHJD9Nz+9dw2SGH4K4xeQJ77YfTq5bRQ+bD8wT11JbeDPmxmGg==",
+          "dev": true,
+          "requires": {
+            "@octokit/openapi-types": "^12.11.0"
+          }
+        }
+      }
+    },
+    "@actions/http-client": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.1.0.tgz",
+      "integrity": "sha512-BonhODnXr3amchh4qkmjPMUO8mFi/zLaaCeCAJZqch8iQqyDnVIkySjB38VHAC8IJ+bnlgfOqlhpyCUZHlQsqw==",
+      "dev": true,
+      "requires": {
+        "tunnel": "^0.0.6"
+      }
+    },
     "@ampproject/remapping": {
       "version": "2.2.0",
       "dev": true,
@@ -11724,17 +11994,6 @@
         "is-plain-object": "^5.0.0",
         "node-fetch": "^2.6.7",
         "universal-user-agent": "^6.0.0"
-      },
-      "dependencies": {
-        "node-fetch": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
-          "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
-          "dev": true,
-          "requires": {
-            "whatwg-url": "^5.0.0"
-          }
-        }
       }
     },
     "@octokit/request-error": {
@@ -14833,6 +15092,15 @@
       "dev": true,
       "requires": {
         "lodash": "^4.17.21"
+      }
+    },
+    "node-fetch": {
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
+      "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
+      "dev": true,
+      "requires": {
+        "whatwg-url": "^5.0.0"
       }
     },
     "node-int64": {
@@ -17994,6 +18262,12 @@
       "requires": {
         "tslib": "^1.8.1"
       }
+    },
+    "tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "dev": true
     },
     "type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   "author": "Shubh Bapna <sbapna@redhat.com>",
   "license": "SEE LICENSE IN LICENSE",
   "devDependencies": {
+    "@actions/github": "^5.1.1",
     "@octokit/rest": "^19.0.5",
     "@types/express": "^4.17.13",
     "@types/follow-redirects": "^1.14.1",

--- a/src/act/act.ts
+++ b/src/act/act.ts
@@ -289,7 +289,7 @@ export class Act {
     let proxy: ForwardProxy | undefined = undefined;
 
     if (opts?.mockApi && opts.mockApi.length > 0) {
-      proxy = new ForwardProxy(opts.mockApi);
+      proxy = new ForwardProxy(opts.mockApi, opts?.verbose);
 
       const address = await proxy.start();
 

--- a/src/proxy/proxy.types.ts
+++ b/src/proxy/proxy.types.ts
@@ -2,6 +2,7 @@ import { Moctokit } from "@kie/mock-github";
 import { Mockapi  } from "@aj/mockapi/mockapi";
 
 export type ResponseMocker = ReturnType<typeof Mockapi.prototype.mock["any"]["any"]["any"]> | ReturnType<Extract<typeof Moctokit.prototype.rest>>;
+export const LOCALHOST = "127.0.0.1";
 
 type Extract<T extends typeof Moctokit.prototype.rest> = {
   [K in keyof T]:  {

--- a/test/unit/proxy/proxy.test.ts
+++ b/test/unit/proxy/proxy.test.ts
@@ -1,13 +1,19 @@
 import { ForwardProxy } from "@aj/proxy/proxy";
 import { Mockapi } from "@aj/mockapi/mockapi";
-import axios from "axios";
-import { Octokit } from "@octokit/rest";
 import { Moctokit } from "@kie/mock-github";
-import { spawn } from "child_process";
+import { SpawnOptionsWithoutStdio, spawn } from "child_process";
+import path from "path";
+import { rmSync, writeFileSync } from "fs";
 
-afterEach(() => {
+const executeRequestFile = path.join(__dirname, "executeRequest.js");
+
+afterEach(async () => {
   delete process.env["http_proxy"];
   delete process.env["https_proxy"];
+});
+
+afterAll(() => {
+  rmSync(executeRequestFile, { force: true });
 });
 
 describe("start", () => {
@@ -42,7 +48,13 @@ describe("stop", () => {
 });
 
 describe("http", () => {
-  test("mock", async () => {
+  let proxy: ForwardProxy;
+  
+  afterEach(async () => {
+    await proxy.stop();
+  });
+
+  test("mock without CONNECT request", async () => {
     const mockapi = new Mockapi({
       google: {
         baseUrl: "http://google.com",
@@ -61,9 +73,9 @@ describe("http", () => {
         },
       },
     });
-    const moctokit = new Moctokit();
+    const moctokit = new Moctokit("http://api.github.com");
 
-    const proxy = new ForwardProxy([
+    proxy = new ForwardProxy([
       mockapi.mock.google.root
         .get()
         .setResponse({ status: 200, data: { msg: "mocked_response" } }),
@@ -72,25 +84,40 @@ describe("http", () => {
         .setResponse({ status: 200, data: { full_name: "mocked_name" } }),
     ]);
     const ip = await proxy.start();
-    process.env["http_proxy"] = `http://${ip}`;
-    process.env["https_proxy"] = `http://${ip}`;
 
-    const axiosResponse = await axios.get("http://google.com/");
-    expect(axiosResponse.data).toStrictEqual({ msg: "mocked_response" });
-
-    const octokit = new Octokit();
-    const octokitResponse = await octokit.rest.repos.get({
-      repo: "kiegroup",
-      owner: "kiegroup",
+    const response = await executeFile(`
+    const axios = require("axios");
+    const {getOctokit} = require("@actions/github")
+    async function run() {
+      const axiosResponse = await axios.get("http://google.com/");
+      const octokit = getOctokit("token");
+      const octokitResponse = await octokit.rest.repos.get({
+        repo: "kiegroup",
+        owner: "kiegroup",
+      });
+      console.log(
+        JSON.stringify({ axios: axiosResponse.data, octokit: octokitResponse.data })
+      );
+    }
+    run();
+    `, {
+      env: {
+        http_proxy: `http://${ip}`,
+        https_proxy: `http://${ip}`,
+        GITHUB_API_URL: "http://api.github.com"
+      }
     });
-    expect(octokitResponse.data).toStrictEqual({ full_name: "mocked_name" });
-    await proxy.stop();
+
+    expect(JSON.parse(response.trim())).toStrictEqual({
+      axios: { msg: "mocked_response" },
+      octokit: { full_name: "mocked_name" }
+    });
   });
 
   test("do not mock", async () => {
     const mockapi = new Mockapi({
-      google: {
-        baseUrl: "http://google.com",
+      gmail: {
+        baseUrl: "http://gmail.com",
         endpoints: {
           root: {
             get: {
@@ -107,84 +134,149 @@ describe("http", () => {
       },
     });
 
-    const proxy = new ForwardProxy([
-      mockapi.mock.google.root
+    proxy = new ForwardProxy([
+      mockapi.mock.gmail.root
         .get()
         .setResponse({ status: 400, data: { msg: "mocked_response" } }),
     ]);
     const ip = await proxy.start();
-    process.env["http_proxy"] = `http://${ip}`;
-    process.env["https_proxy"] = `http://${ip}`;
 
-    const { status } = await axios.get("http://redhat.com/");
-
-    expect(
-      status
-    ).toBe(200);
-    await proxy.stop();
-  });
-});
-
-describe("https", () => {
-  test("some clients send a CONNECT request, in which case don't mock it even if it matches", async () => {
-    const mockapi = new Mockapi({
-      google: {
-        baseUrl: "http://google.com",
-        endpoints: {
-          root: {
-            get: {
-              path: "/",
-              method: "get",
-              parameters: {
-                query: [],
-                path: [],
-                body: [],
-              },
-            },
-          },
-        },
-      },
+    const response = await executeFile(`
+    const axios = require("axios");
+    axios.get("http://redhat.com/").then(d => console.log(d.status))
+    `, {
+      env: {
+        http_proxy: `http://${ip}`,
+        https_proxy: `http://${ip}`,
+      }
     });
 
-    const proxy = new ForwardProxy([
-      mockapi.mock.google.root
-        .get()
-        .setResponse({ status: 200, data: { msg: "mocked_response" } }),
-    ]);
-    const ip = await proxy.start();
-    process.env["http_proxy"] = `http://${ip}`;
-    process.env["https_proxy"] = `http://${ip}`;
-
-    const response = await executeCurl(["-s", "https://google.com"]);
-    expect(response).toMatch(/<HTML><HEAD>.+/);
-    await proxy.stop();
+    expect(response.trim()).toBe("200");
   });
 
-  test("some clients dont send a CONNECT request in which case mock it", async () => {
-    const moctokit = new Moctokit();
+  test("mock with CONNECT request", async () => {
+    const moctokit = new Moctokit("http://api.github.com");
 
-    const proxy = new ForwardProxy([
+    proxy = new ForwardProxy([
       moctokit.rest.repos
         .get()
         .setResponse({ status: 200, data: { full_name: "mocked_name" } }),
     ]);
     const ip = await proxy.start();
-    process.env["http_proxy"] = `http://${ip}`;
-    process.env["https_proxy"] = `http://${ip}`;
-    const octokit = new Octokit();
-    const response = await octokit.rest.repos.get({
+
+    const response = await executeFile(`
+    const {getOctokit} = require("@actions/github")
+    const octokit = getOctokit("token");
+    octokit.rest.repos.get({
       repo: "kiegroup",
       owner: "kiegroup",
+    }).then(data => console.log(JSON.stringify({status: data.status, data: data.data})));
+    `, {
+      env: {
+        http_proxy: `http://${ip}`,
+        https_proxy: `http://${ip}`,
+        GITHUB_API_URL: "http://api.github.com"
+      }
     });
-    expect(response.data).toStrictEqual({ full_name: "mocked_name" });
 
-    await proxy.stop();
+    expect(JSON.parse(response.trim())).toStrictEqual({ status: 200, data: {full_name: "mocked_name"} });
   });
 });
 
-async function executeCurl(args: string[]) {
+describe("https", () => {
+  let mockapi: Mockapi;
+  let proxy: ForwardProxy;
+
+  beforeEach(() => {
+    mockapi = new Mockapi({
+      google: {
+        baseUrl: "http://google.com",
+        endpoints: {
+          root: {
+            get: {
+              path: "/",
+              method: "get",
+              parameters: {
+                query: [],
+                path: [],
+                body: [],
+              },
+            },
+          },
+        },
+      },
+    });
+  });
+
+  afterEach(async () => {
+    await proxy.stop();
+  });
+  
+  test("don't mock when a CONNECT request is sent", async () => {
+    proxy = new ForwardProxy([
+      mockapi.mock.google.root
+        .get()
+        .setResponse({ status: 200, data: { msg: "mocked_response" } }),
+    ]);
+    const ip = await proxy.start();
+
+    const response = await executeCurl(["-s", "https://google.com"], {
+      env: {
+        http_proxy: `http://${ip}`,
+        https_proxy: `http://${ip}`
+      }
+    });
+    expect(response).toMatch(/<HTML><HEAD>.+/);
+  });
+
+  test("mock when a CONNECT request is not sent", async () => {
+    proxy = new ForwardProxy([
+      mockapi.mock.google.root
+        .get()
+        .setResponse({ status: 200, data: { msg: "mocked_response" } }),
+    ]);
+    const ip = await proxy.start();
+    
+    const response = await executeFile(`
+    const axios = require("axios");
+    axios.get("https://google.com").then(d => console.log(JSON.stringify({status: d.status, data: d.data})))
+    `, {
+      env: {
+        http_proxy: `http://${ip}`,
+        https_proxy: `http://${ip}`,
+      }
+    });
+
+    expect(JSON.parse(response.trim())).toStrictEqual({status: 200, data: {msg: "mocked_response"}});
+  });
+});
+
+async function executeCurl(args: string[], options?: SpawnOptionsWithoutStdio) {
   return new Promise((resolve, reject) => {
-    const childProcess = spawn("curl", args);
+    const childProcess = spawn("curl", args, options);
+    let data = "";
+    let error = "";
+    childProcess.stdout.on("data", chunk => {
+      data += chunk.toString();
+    });
+    childProcess.stderr.on("data", chunk => {
+      error += chunk.toString();
+    });
+
+    childProcess.on("close", code => {
+      if (code === null) {
+        reject(error);
+      } else {
+        resolve(data);
+      }
+    });
+  });
+}
+
+async function executeFile(request: string, options?: SpawnOptionsWithoutStdio): Promise<string> {
+  writeFileSync(executeRequestFile, request);
+  return new Promise((resolve, reject) => {
+    const childProcess = spawn("node", [executeRequestFile], options);
     let data = "";
     let error = "";
     childProcess.stdout.on("data", chunk => {


### PR DESCRIPTION
Fixes https://github.com/kiegroup/mock-github/issues/72

There seems to be some inconsistency between different client implementations on how to handle proxying when the destination is `http` only. The [rfc](https://www.rfc-editor.org/rfc/rfc9110#name-connect) suggests that `CONNECT` is used to setup a tunnel which can later be secured by TLS

> The CONNECT method requests that the recipient establish a tunnel to the destination origin server identified by the request target and, if successful, thereafter restrict its behavior to blind forwarding of data, in both directions, until the tunnel is closed. Tunnels are commonly used to create an end-to-end virtual connection, through one or more proxies, which can then be secured using TLS (Transport Layer Security, [[TLS13](https://www.rfc-editor.org/rfc/rfc9110#TLS13)]).

This could be interpreted as you don't necessarily need a TLS tunnel and so a client is allowed to issue a CONNECT request for a http destination.

There has been no response from the maintainers of `@actions/toolkit`, so I am not sure whether they will accept my PR to change their proxying library (see https://github.com/kiegroup/mock-github/issues/72#issuecomment-1569223066). 

Either way, there might be more clients out there that send `CONNECT` requests for http destinations. This PR aims to support such clients.

However, I still believe that it is redundant to do so, since there is no advantage of a tunnel when the destination is http only. The proxy can still read the messages that go through. Even `curl`'s default behavior is to send the http request directly to the proxy without issuing a `CONNECT` request for such cases.

## Implementation details

The idea here was to "fool" the client when the proxy receives a `CONNECT` request. The proxy will respond back with OK but won't actually setup a tcp tunnel and try to process the request on its own.

However, in node.js when the server receives a "connect" event (i.e. a `CONNECT` request) it removes all data handlers from the client's socket including the in built node.js http parsers:
1. https://nodejs.org/api/http.html#event-connect_1
2. https://github.com/nodejs/node/blob/main/lib/_http_server.js#L930C5-L933C19

So the proxy is only able receive raw http requests by reattaching the data handlers (i.e. all the express request handlers are removed). Now for the proxy to process the request that comes after the `CONNECT` request it will have to parse the raw http request. 

Instead of trying to parse the raw http request and missing any important details, I decided to spin up another forward proxy. The first forward proxy then sets up a tunnel between the client and the second forward proxy which then receives the http request and processes it easily.

## Drawbacks

Spinning up another forward proxy is a costly operation. For future improvements, we should try to figure out the best way to parse the raw http or reattach the data and request handlers for the client's socket


