### PR TITLE
fix: allow selective override of keys in `inputs` field in the workflow file when using `setInput`

### DIFF
--- a/src/action-input/action-input.ts
+++ b/src/action-input/action-input.ts
@@ -17,7 +17,11 @@ export class ActionInput {
   toActArguments() {
     if (Object.keys(this.event.event).length > 0) {
       const eventCopy = { ...this.event.event };
-      eventCopy.inputs = Object.fromEntries(this.input.map);
+      // Merge inputs with existing event entries
+      eventCopy.inputs = { 
+        ...(eventCopy.inputs || {}), 
+        ...Object.fromEntries(this.input.map) 
+      };
       this.event.event = eventCopy;
       return [];
     } else {


### PR DESCRIPTION
When triggering a `workflow_dispatch` event, the event payload must contain the `inputs` key.

However, this key is always overwritten as the code is currently written.

This change allows the simultaneous use of `act.setInput()` and passing an event payload containing an `inputs` key.