### PR TITLE
fix: Improve error message on mockStep failure

### DIFF
--- a/src/step-mocker/step-mocker.ts
+++ b/src/step-mocker/step-mocker.ts
@@ -43,7 +43,9 @@ export class StepMocker {
             this.updateStep(workflow, jobId, stepIndex, mockStep);
           }
         } else {
-          throw new Error("Could not find step");
+          const stepQuery = { ...mockStep };
+          delete stepQuery.mockWith;
+          throw new Error(`Could not find step ${JSON.stringify(stepQuery)} in job ${jobId}\nin ${filePath}`);
         }
       }
       stepsToAdd.forEach(s => this.addStep(workflow, s.jobId, s.stepIndex, s.mockStep));

--- a/src/step-mocker/step-mocker.ts
+++ b/src/step-mocker/step-mocker.ts
@@ -43,8 +43,7 @@ export class StepMocker {
             this.updateStep(workflow, jobId, stepIndex, mockStep);
           }
         } else {
-          const stepQuery = { ...mockStep };
-          delete stepQuery.mockWith;
+          const { mockWith, ...stepQuery } = mockStep;
           throw new Error(`Could not find step ${JSON.stringify(stepQuery)} in job ${jobId}\nin ${filePath}`);
         }
       }

--- a/src/step-mocker/step-mocker.ts
+++ b/src/step-mocker/step-mocker.ts
@@ -43,7 +43,7 @@ export class StepMocker {
             this.updateStep(workflow, jobId, stepIndex, mockStep);
           }
         } else {
-          const { mockWith, ...stepQuery } = mockStep;
+          const { mockWith: _, ...stepQuery } = mockStep;
           throw new Error(`Could not find step ${JSON.stringify(stepQuery)} in job ${jobId}\nin ${filePath}`);
         }
       }

--- a/test/unit/step-mocker/step-mocker.test.ts
+++ b/test/unit/step-mocker/step-mocker.test.ts
@@ -103,7 +103,8 @@ describe("locateSteps", () => {
     existsSyncMock.mockReturnValueOnce(true);
     writeFileSyncMock.mockReturnValueOnce(undefined);
   });
-  test("no job found", async () => {
+
+  test("no job found using wrong name", async () => {
     readFileSyncMock.mockReturnValueOnce(
       await readFile(path.join(resources, "steps.yaml"), "utf8")
     );
@@ -117,7 +118,7 @@ describe("locateSteps", () => {
           },
         ],
       })
-    ).rejects.toThrowError();
+    ).rejects.toThrowError(`Could not find step {"name":"step"} in job incorrectName\nin ${path.join(__dirname, "workflow.yaml")}`);
   });
 
   test("step found using id", async () => {
@@ -142,6 +143,23 @@ describe("locateSteps", () => {
     );
   });
 
+  test("no step found using incorrect id", async () => {
+    readFileSyncMock.mockReturnValueOnce(
+        await readFile(path.join(resources, "steps.yaml"), "utf8")
+    );
+    const stepMocker = new StepMocker("workflow.yaml", __dirname);
+    await expect(
+        stepMocker.mock({
+          name: [
+            {
+              id: "not-echo",
+              mockWith: "echo step",
+            },
+          ],
+        })
+    ).rejects.toThrowError(`Could not find step {"id":"not-echo"} in job name\nin ${path.join(__dirname, "workflow.yaml")}`);
+  });
+
   test("step found using name", async () => {
     const data = await readFile(path.join(resources, "steps.yaml"), "utf8");
     readFileSyncMock.mockReturnValueOnce(data);
@@ -160,6 +178,23 @@ describe("locateSteps", () => {
       workflow,
       "utf8"
     );
+  });
+
+  test("no step found using incorrect name", async () => {
+    readFileSyncMock.mockReturnValueOnce(
+        await readFile(path.join(resources, "steps.yaml"), "utf8")
+    );
+    const stepMocker = new StepMocker("workflow.yaml", __dirname);
+    await expect(
+        stepMocker.mock({
+          name: [
+            {
+              name: "Incorrect Name",
+              mockWith: "echo step",
+            },
+          ],
+        })
+    ).rejects.toThrowError(`Could not find step {"name":"Incorrect Name"} in job name\nin ${path.join(__dirname, "workflow.yaml")}`);
   });
 
   test("step found using uses", async () => {
@@ -184,6 +219,23 @@ describe("locateSteps", () => {
     );
   });
 
+  test("no step found using incorrect uses", async () => {
+    readFileSyncMock.mockReturnValueOnce(
+        await readFile(path.join(resources, "steps.yaml"), "utf8")
+    );
+    const stepMocker = new StepMocker("workflow.yaml", __dirname);
+    await expect(
+        stepMocker.mock({
+          name: [
+            {
+              uses: "invalid/action@v0",
+              mockWith: "echo step",
+            },
+          ],
+        })
+    ).rejects.toThrowError(`Could not find step {"uses":"invalid/action@v0"} in job name\nin ${path.join(__dirname, "workflow.yaml")}`);
+  });
+
   test("step found using run", async () => {
     const data = await readFile(path.join(resources, "steps.yaml"), "utf8");
     readFileSyncMock.mockReturnValueOnce(data);
@@ -203,7 +255,24 @@ describe("locateSteps", () => {
       "utf8"
     );
   });
-  
+
+  test("no step found using incorrect run", async () => {
+    readFileSyncMock.mockReturnValueOnce(
+        await readFile(path.join(resources, "steps.yaml"), "utf8")
+    );
+    const stepMocker = new StepMocker("workflow.yaml", __dirname);
+    await expect(
+        stepMocker.mock({
+          name: [
+            {
+              run: "echo incorrect",
+              mockWith: "echo step",
+            },
+          ],
+        })
+    ).rejects.toThrowError(`Could not find step {"run":"echo incorrect"} in job name\nin ${path.join(__dirname, "workflow.yaml")}`);
+  });
+
   test("step found using index", async () => {
     const data = await readFile(path.join(resources, "steps.yaml"), "utf8");
     readFileSyncMock.mockReturnValueOnce(data);
@@ -222,6 +291,23 @@ describe("locateSteps", () => {
       workflow,
       "utf8"
     );
+  });
+
+  test("no step found using incorrect index", async () => {
+    readFileSyncMock.mockReturnValueOnce(
+        await readFile(path.join(resources, "steps.yaml"), "utf8")
+    );
+    const stepMocker = new StepMocker("workflow.yaml", __dirname);
+    await expect(
+        stepMocker.mock({
+          name: [
+            {
+              index: 42,
+              mockWith: "echo step",
+            },
+          ],
+        })
+    ).rejects.toThrowError(`Could not find step {"index":42} in job name\nin ${path.join(__dirname, "workflow.yaml")}`);
   });
 
   test.each([


### PR DESCRIPTION
This helps to find which mock rule is not working. If there are multiple `mockSteps`, it's hard to figure out otherwise which one is wrong. This helps clarify it.

Before:
```
Error: Could not find step
    at StepMocker.mock (.../node_modules/@kie/act-js/build/src/step-mocker/step-mocker.js:35:27)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Promise.all (index 0)
```

After:
```
Error: Could not find step {"uses":"actions/upload-artifact@v4"} in job unit-test
in /foo/bar/baz/tests/repo/testRepo/.github/workflows/ci.yml

    at StepMocker.mock (/foo/bar/baz/tests/node_modules/@kie/act-js/build/src/step-mocker/step-mocker.js:37:27)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Promise.all (index 0)
```