### PR TITLE
chore: Fail CI on lint warnings

### DIFF
--- a/test/unit/mockapi/mockapi.test.ts
+++ b/test/unit/mockapi/mockapi.test.ts
@@ -12,7 +12,7 @@ describe("from file", () => {
     mockapi.mock.google.root
       .get({ search: /test.*/ })
       .reply({ status: 200, data: { message: "worked" } });
-    const { status, data, invalid } = await axios.get(
+    const { status, data } = await axios.get(
       "https://google.com/?search=test123"
     );
     expect(status).toBe(200);


### PR DESCRIPTION
Following up from https://github.com/kiegroup/act-js/pull/74#issuecomment-1939746403

Related reading https://dev.to/thawkin3/eslint-warnings-are-an-anti-pattern-33np