### PR TITLE
fix: Update act Dependency to v0.2.61 for Node 20 Actions Support

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "nektos/act"
   ],
   "scripts": {
-    "postinstall": "node scripts/postinstall.js 0.2.48",
+    "postinstall": "node scripts/postinstall.js 0.2.61",
     "build": "tsc && tsc-alias",
     "pretest:it": "npm run postinstall && mkdir -p bin && cp build/bin/* bin/",
     "test": "npm run test:unit && npm run test:it",


### PR DESCRIPTION
### Changes

This pull request updates the `act` dependency in `act-js` from v0.2.48 to v0.2.61. This update is crucial as it introduces support for Node 20, enabling `act-js` to handle workflows that utilize the latest versions of GitHub Actions requiring Node 20.

### Why is this change necessary?

The current default version of `act` used by `act-js` (v0.2.48) does not support Node 20, leading to failures when users attempt to execute workflows that depend on this Node version. By updating to `act` v0.2.61, we ensure compatibility with workflows having actions designed for Node 20, improving the tool's usability and reliability.

### Related issues
- #78 
- [#2050](https://github.com/nektos/act/issues/2050)
