### PR TITLE
bump act version to 0.2.77

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -9,6 +9,8 @@ on:
       - '.github/workflows/**'
       - 'test/ci/**'
       - 'jest.config.ts'
+  
+  workflow_dispatch:
 
 jobs:
   unit:

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "nektos/act"
   ],
   "scripts": {
-    "postinstall": "node scripts/postinstall.js 0.2.61",
+    "postinstall": "node scripts/postinstall.js 0.2.77",
     "build": "tsc && tsc-alias",
     "pretest:it": "npm run postinstall && mkdir -p bin && cp build/bin/* bin/",
     "test": "npm run test:unit && npm run test:it",


### PR DESCRIPTION
Bump the automatically-installed version of `act` to the latest as of this PR: `0.2.77`.